### PR TITLE
fix: 修正 CustomFormatter 與 Monolog 2.x 相容性問題

### DIFF
--- a/app/Models/Logging/Formatter/CustomFormatter.php
+++ b/app/Models/Logging/Formatter/CustomFormatter.php
@@ -4,13 +4,10 @@ namespace App\Models\Logging\Formatter;
 
 use App\Models\Logging\Services\LoggingService;
 use Monolog\Formatter\LineFormatter;
-use Monolog\LogRecord;
 
 class CustomFormatter extends LineFormatter
 {
     public const SIMPLE_DATE = "Y-m-d H:i:s";
-
-    protected bool $includeStacktraces = true;
 
     /**
      * @param string $format The format of the message
@@ -20,9 +17,15 @@ class CustomFormatter extends LineFormatter
         $this->format = $format ?: '[%datetime%] [' . getmypid() . "] [%prefix%] (%index%) %channel%.%level_name%: %message% %context% %extra%\n";
 
         parent::__construct($this->format, null, true, true);
+        
+        // Set stacktraces to be included
+        $this->includeStacktraces(true);
     }
 
-    public function format(LogRecord $record): string
+    /**
+     * {@inheritdoc}
+     */
+    public function format(array $record): string
     {
         $output = parent::format($record);
 
@@ -36,7 +39,7 @@ class CustomFormatter extends LineFormatter
         );
 
         foreach ($vars as $key => $var) {
-            $output = str_replace('%' . $key . '%', $var, $output);
+            $output = str_replace('%' . $key . '%', $var ?? '', $output);
         }
 
         return $output;


### PR DESCRIPTION
- 移除重複的 $includeStacktraces 屬性定義，避免與父類別衝突
- 修正 format() 方法簽名以相容 Monolog 2.x（接受 array 而非 LogRecord）
- 新增空值合併運算子防止字串替換時出現 null 警告
- 使用 includeStacktraces() 方法而非屬性覆寫

此修正解決了 PHP 錯誤：'CustomFormatter::$includeStacktraces 不能重新定義'